### PR TITLE
[tests] Modify unit test for Arthur Worker using fakeredis module instead of redis

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@
 
 import unittest
 
-from redis import StrictRedis
+from fakeredis import FakeStrictRedis
 from rq import pop_connection, push_connection
 
 
@@ -29,17 +29,9 @@ from rq import pop_connection, push_connection
 # to their authors.
 
 def find_empty_redis_database():
-    """Connect to a random Redis database.
-
-    Tries to connect a random Redis database (starting on 8) and
-    will use/connect it when no keys are stored in there.
-    """
-    for db in range(8, 16):
-        conn = StrictRedis(db=db)
-        empty = len(conn.keys('*')) == 0
-        if empty:
-            return conn
-    assert False, "No empty Redis database found to run tests in."
+    """Connect to a fake Redis database"""
+    conn = FakeStrictRedis()
+    return conn
 
 
 class TestBaseRQ(unittest.TestCase):
@@ -54,7 +46,7 @@ class TestBaseRQ(unittest.TestCase):
     def tearDownClass(cls):
         conn = pop_connection()
         assert conn == cls.conn, \
-            "Wow, something really nasty happened to the Redis connection stack. Check your setup."
+            "Wow, something really nasty happened to the FakeRedis connection stack. Check your setup."
 
     def setUp(self):
         self.conn.flushdb()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -25,7 +25,7 @@ import pickle
 import sys
 import unittest
 
-import rq
+import rq.worker
 
 if not '..' in sys.path:
     sys.path.insert(0, '..')
@@ -34,6 +34,11 @@ from arthur.common import CH_PUBSUB
 from arthur.worker import ArthurWorker
 
 from tests import TestBaseRQ, mock_sum, mock_failure
+
+
+class MockArthurWorker(rq.worker.SimpleWorker, ArthurWorker):
+    """Unit tests for ArthurWorker class, avoids rq inheritance problems"""
+    pass
 
 
 class TestArthurWorker(TestBaseRQ):
@@ -46,7 +51,7 @@ class TestArthurWorker(TestBaseRQ):
         pubsub.subscribe(CH_PUBSUB)
 
         q = rq.Queue('foo')
-        w = ArthurWorker([q])
+        w = MockArthurWorker([q])
 
         job_a = q.enqueue(mock_sum, a=2, b=3)
         job_b = q.enqueue(mock_failure)


### PR DESCRIPTION
As the unit tests need a connection with a Redis database, a "real" server must be up to run the tests.  With this change, this "real" server is replaced by fakeredis library to emulate the use of a server.
