### PR TITLE
[setup] Improve generation of package and running tests

### DIFF
--- a/arthur/_version.py
+++ b/arthur/_version.py
@@ -1,2 +1,2 @@
 # Versions compliant with PEP 440 https://www.python.org/dev/peps/pep-0440
-__version__ = "0.1.0.dev1"
+__version__ = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@
 import codecs
 import os.path
 import re
+import sys
 
 from setuptools import setup
 
@@ -42,7 +43,7 @@ try:
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
     print("Warning: pypandoc module not found, or pandoc not installed. "
-          "Using md instead of rst")
+          "Using md instead of rst", file=sys.stderr)
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()
 
@@ -51,7 +52,7 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 
-setup(name="arthur",
+setup(name="kingarthur",
       description="Distributed job queue platform for scheduling Perceval jobs",
       long_description=long_description,
       url="https://github.com/grimoirelab/arthur",
@@ -70,6 +71,8 @@ setup(name="arthur",
       packages=[
           'arthur'
       ],
+      python_requires='>=3.4',
+      setup_requires=['wheel'],
       install_requires=[
           'python-dateutil>=2.6.0',
           'redis>=2.10.0',
@@ -78,6 +81,8 @@ setup(name="arthur",
           'perceval>=0.8.0',
           'grimoirelab-toolkit>=0.1.0'
       ],
+      tests_require=['httpretty==0.8.6', 'fakeredis'],
+      test_suite='tests',
       scripts=[
           'bin/arthur',
           'bin/arthurd',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,7 @@
 #
 #
 
+import os.path
 import unittest
 
 from fakeredis import FakeStrictRedis
@@ -41,6 +42,7 @@ class TestBaseRQ(unittest.TestCase):
     def setUpClass(cls):
         cls.conn = find_empty_redis_database()
         push_connection(cls.conn)
+        cls.dir = os.path.dirname(os.path.realpath(__file__))
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_arthur.py
+++ b/tests/test_arthur.py
@@ -22,6 +22,7 @@
 #
 
 import os
+import os.path
 import shutil
 import subprocess
 import sys
@@ -44,8 +45,10 @@ class TestArthur(unittest.TestCase):
         cls.tmp_path = tempfile.mkdtemp(prefix='arthur_')
         cls.git_path = os.path.join(cls.tmp_path, 'gittest')
 
-        subprocess.check_call(['tar', '-xzf', 'data/gittest.tar.gz',
-                               '-C', cls.tmp_path])
+        dir = os.path.dirname(os.path.realpath(__file__))
+        subprocess.check_call(['tar', '-xzf',
+                                os.path.join(dir, 'data/gittest.tar.gz'),
+                                            '-C', cls.tmp_path])
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -22,6 +22,7 @@
 #
 
 import datetime
+import os.path
 import pickle
 import shutil
 import sys
@@ -69,12 +70,11 @@ REDMINE_URL_LIST = [
     REDMINE_USER_4_URL, REDMINE_USER_24_URL, REDMINE_USER_25_URL
 ]
 
-
 def read_file(filename, mode='r'):
-    with open(filename, mode) as f:
+    dir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(dir, filename), mode) as f:
         content = f.read()
     return content
-
 
 def setup_mock_bugzilla_server():
     """Setup a mock Bugzilla server for testing"""
@@ -306,7 +306,7 @@ class TestPercevalJob(TestBaseRQ):
                           self.conn, 'items')
         args = {
             'uri': 'http://example.com/',
-            'gitpath': 'data/git_log.txt'
+            'gitpath': os.path.join(self.dir, 'data/git_log.txt')
         }
 
         job.run(args, fetch_from_cache=False)
@@ -563,7 +563,7 @@ class TestExecuteJob(TestBaseRQ):
 
         args = {
             'uri': 'http://example.com/',
-            'gitpath': 'data/git_log.txt'
+            'gitpath': os.path.join(self.dir, 'data/git_log.txt')
         }
 
         q = rq.Queue('queue', async=False)
@@ -672,7 +672,7 @@ class TestExecuteJob(TestBaseRQ):
 
         args = {
             'uri': 'http://example.com/',
-            'gitpath': 'data/git_log_empty.txt',
+            'gitpath': os.path.join(self.dir, 'data/git_log_empty.txt'),
             'from_date': datetime.datetime(2020, 1, 1, 1, 1, 1)
         }
 
@@ -772,7 +772,7 @@ class TestExecuteJob(TestBaseRQ):
 
         args = {
             'uri': 'http://example.com/',
-            'gitpath': 'data/git_log.txt'
+            'gitpath': os.path.join(self.dir, 'data/git_log.txt')
         }
 
         q = rq.Queue('queue', async=False)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -21,6 +21,7 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+import os.path
 import sys
 import unittest
 
@@ -43,7 +44,7 @@ class TestScheduler(TestBaseRQ):
 
         args = {
             'uri': 'http://example.com/',
-            'gitpath': 'data/git_log.txt'
+            'gitpath': os.path.join(self.dir, 'data/git_log.txt')
         }
         cache_args = {
             'cache_path': None,


### PR DESCRIPTION
Some more parameters for Setup in setup.py, such as dependencies for tests, or specific Python versions supported.

Adaption of the tests to run via setyp.py. Now, tests can be
checked by running `python setup.py test`.

So the schema to build packages is:

```
python setup.py test
python setup.py sdist
python setup.py bdist_wheel
```

Version in _version.py moved to first non-dev (0.0.1).