### PR TITLE
[setup] Fix six>=1.11.0 distribution not found

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil>=2.6.0
 redis>=2.10.0
 rq>=0.6.0
-cherrypy>=8.1
+cherrypy>=8.1, <=11.0.0
 -e git+https://github.com/grimoirelab/grimoirelab-toolkit/#egg=grimoirelab-toolkit
 -e git+https://github.com/grimoirelab/perceval.git/#egg=perceval

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(name="kingarthur",
           'python-dateutil>=2.6.0',
           'redis>=2.10.0',
           'rq>=0.6.0',
-          'cherrypy>=8.1',
+          'cherrypy>=8.1, <=11.0.0',
           'perceval>=0.8.0',
           'grimoirelab-toolkit>=0.1.0'
       ],

--- a/tests/test_arthur.py
+++ b/tests/test_arthur.py
@@ -47,8 +47,8 @@ class TestArthur(unittest.TestCase):
 
         dir = os.path.dirname(os.path.realpath(__file__))
         subprocess.check_call(['tar', '-xzf',
-                                os.path.join(dir, 'data/gittest.tar.gz'),
-                                            '-C', cls.tmp_path])
+                               os.path.join(dir, 'data/gittest.tar.gz'),
+                               '-C', cls.tmp_path])
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -70,11 +70,13 @@ REDMINE_URL_LIST = [
     REDMINE_USER_4_URL, REDMINE_USER_24_URL, REDMINE_USER_25_URL
 ]
 
+
 def read_file(filename, mode='r'):
     dir = os.path.dirname(os.path.realpath(__file__))
     with open(os.path.join(dir, filename), mode) as f:
         content = f.read()
     return content
+
 
 def setup_mock_bugzilla_server():
     """Setup a mock Bugzilla server for testing"""


### PR DESCRIPTION
This PR fixes the missing distribution six>=1.11.0.
The problem is due to the fact that **cheerypy** requires the dependency with **six** to be >=1.11.0. However this distribution is not available for python 3.4.

The proposed solution sets the **cheerpy** dependency to >=8.1, <=11.0.0 (versions that do not force **six** to be greater than 1.11.0). An alternative solution could be to use of python 3.4 instead of 3.5.